### PR TITLE
Refactor interface between NCrystal and OpenMC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,6 +348,7 @@ list(APPEND libopenmc_SOURCES
   src/message_passing.cpp
   src/mgxs.cpp
   src/mgxs_interface.cpp
+  src/ncrystal_interface.cpp
   src/nuclide.cpp
   src/output.cpp
   src/particle.cpp

--- a/docs/source/methods/cross_sections.rst
+++ b/docs/source/methods/cross_sections.rst
@@ -182,19 +182,22 @@ been selected. There are three methods available:
 NCrystal materials
 ------------------
 
-As an alternative of the standard thermal scattering treatment using :math:`S(\alpha,\beta)`
-tables, OpenMC allows to create materials using NCrystal_. In addition to the regular thermal elastic,
-and thermal inelastic processes, NCrystal allows the generation of models for materials that 
-cannot currently included in ACE files such as oriented single crystals (see the `NCrystal paper`_),
-and further extend the physics `using plugins`_. Thermal scattering kernels are generated on
-the fly from dynamic and structural data, or loaded from :math:`S(\alpha,\beta)` tables converted
-from ENDF6 evaluations. These kernels are sampled in a direct way using a fast `rejection algorithm`_ 
-that does not require previous processing. A `large library`_ of materials is already included in
-the NCrystal distribution, and new materials can be easily defined from scratch in the `NCMAT format`_
-or `combining existing files`_.
+As an alternative of the standard thermal scattering treatment using
+:math:`S(\alpha,\beta)` tables, OpenMC allows to create materials using
+NCrystal_. In addition to the regular thermal elastic, and thermal inelastic
+processes, NCrystal allows the generation of models for materials that cannot
+currently included in ACE files such as oriented single crystals (see the
+`NCrystal paper`_), and further extend the physics `using plugins`_. Thermal
+scattering kernels are generated on the fly from dynamic and structural data, or
+loaded from :math:`S(\alpha,\beta)` tables converted from ENDF6 evaluations.
+These kernels are sampled in a direct way using a fast `rejection algorithm`_
+that does not require previous processing. A `large library`_ of materials is
+already included in the NCrystal distribution, and new materials can be easily
+defined from scratch in the `NCMAT format`_ or `combining existing files`_.
 
-The compositions of the materials defined in NCrystal are passed on to OpenMC all other reactions 
-except for thermal neutron scattering are handled by continuous energy ACE libraries.
+The compositions of the materials defined in NCrystal are passed on to OpenMC
+all other reactions except for thermal neutron scattering are handled by
+continuous energy ACE libraries.
 
 ----------------
 Multi-Group Data

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -274,9 +274,10 @@ Prerequisites
     * NCrystal_ library for defining materials with enhanced thermal neutron transport
 
       Adding this option allows the creation of materials from NCrystal, which
-      replaces the scattering kernel treatment of ACE files with a modular, on-the-fly approach.
-      To use it `install <https://github.com/mctools/ncrystal/wiki/Get-NCrystal>`_ and 
-      `initialize <https://github.com/mctools/ncrystal/wiki/Using-NCrystal#setting-up>`_
+      replaces the scattering kernel treatment of ACE files with a modular,
+      on-the-fly approach. To use it `install
+      <https://github.com/mctools/ncrystal/wiki/Get-NCrystal>`_ and `initialize
+      <https://github.com/mctools/ncrystal/wiki/Using-NCrystal#setting-up>`_
       NCrystal and turn on the option in the CMake configuration step:
 
           cmake -DOPENMC_USE_NCRYSTAL=on ..
@@ -374,8 +375,8 @@ OPENMC_USE_DAGMC
   (Default: off)
 
 OPENMC_USE_NCRYSTAL
-  Turns on support for NCrystal materials. NCrystal must be 
-  `installed <https://github.com/mctools/ncrystal/wiki/Get-NCrystal>`_ and 
+  Turns on support for NCrystal materials. NCrystal must be
+  `installed <https://github.com/mctools/ncrystal/wiki/Get-NCrystal>`_ and
   `initialized <https://github.com/mctools/ncrystal/wiki/Using-NCrystal#setting-up>`_.
   (Default: off)
 

--- a/docs/source/usersguide/materials.rst
+++ b/docs/source/usersguide/materials.rst
@@ -105,12 +105,14 @@ you would need to add hydrogen and oxygen to a material and then assign the
 Adding NCrystal materials
 -------------------------
 
-Additional support for thermal scattering can be added by using NCrystal_.
-The :meth:`Material.from_ncrystal` class method generates a :class:`openmc.Material` object from
-an `NCrystal configuration string <https://github.com/mctools/ncrystal/wiki/Using-NCrystal#uniform-material-configuration-syntax>`_.
-Temperature, material composition, and density are passed from the configuration string
-and the `NCMAT file <https://github.com/mctools/ncrystal/wiki/NCMAT-format>`_
-that define the material, e.g.::
+Additional support for thermal scattering can be added by using NCrystal_. The
+:meth:`Material.from_ncrystal` class method generates a :class:`openmc.Material`
+object from an `NCrystal configuration string
+<https://github.com/mctools/ncrystal/wiki/Using-NCrystal#uniform-material-configuration-syntax>`_.
+Temperature, material composition, and density are passed from the configuration
+string and the `NCMAT file
+<https://github.com/mctools/ncrystal/wiki/NCMAT-format>`_ that define the
+material, e.g.::
 
    mat = openmc.Material.from_ncrystal('Al_sg225.ncmat;temp=300K')
 
@@ -125,12 +127,12 @@ defines a material containing polycrystalline alumnium,
 defines an oriented germanium single crystal with 40 arcsec mosaicity.
 
 NCrystal only handles low energy neutron interactions. Other interactions are
-provided by standard ACE files. NCrystal_ comes with a `predefined library 
+provided by standard ACE files. NCrystal_ comes with a `predefined library
 <https://github.com/mctools/ncrystal/wiki/Data-library>`_ but more materials can
 be added by creating NCMAT files or on-the-fly in the configuration string.
 
-.. warning:: Currently, NCrystal_ materials cannot be modified after they are created. 
-             Density, temperature and composition should be defined in the 
+.. warning:: Currently, NCrystal_ materials cannot be modified after they are created.
+             Density, temperature and composition should be defined in the
              configuration string or the NCMAT file.
 
 .. _NCrystal: https://github.com/mctools/ncrystal

--- a/include/openmc/material.h
+++ b/include/openmc/material.h
@@ -12,12 +12,9 @@
 #include "openmc/bremsstrahlung.h"
 #include "openmc/constants.h"
 #include "openmc/memory.h" // for unique_ptr
+#include "openmc/ncrystal_interface.h"
 #include "openmc/particle.h"
 #include "openmc/vector.h"
-
-#ifdef NCRYSTAL
-#include "NCrystal/NCrystal.hh"
-#endif
 
 namespace openmc {
 
@@ -155,25 +152,17 @@ public:
   //! \return Temperature in [K]
   double temperature() const;
 
-#ifdef NCRYSTAL
   //! Get pointer to NCrystal material object
   //! \return Pointer to NCrystal material object
-  std::shared_ptr<const NCrystal::ProcImpl::Process> ncrystal_mat() const
-  {
-    return ncrystal_mat_;
-  };
-#endif
+  const NCrystalMat& ncrystal_mat() const { return ncrystal_mat_; };
 
   //----------------------------------------------------------------------------
   // Data
-  int32_t id_ {C_NONE}; //!< Unique ID
-  std::string name_;    //!< Name of material
-  vector<int> nuclide_; //!< Indices in nuclides vector
-  vector<int> element_; //!< Indices in elements vector
-#ifdef NCRYSTAL
-  std::string ncrystal_cfg_; //!< NCrystal configuration string
-  std::shared_ptr<const NCrystal::ProcImpl::Process> ncrystal_mat_;
-#endif
+  int32_t id_ {C_NONE};                 //!< Unique ID
+  std::string name_;                    //!< Name of material
+  vector<int> nuclide_;                 //!< Indices in nuclides vector
+  vector<int> element_;                 //!< Indices in elements vector
+  NCrystalMat ncrystal_mat_;            //!< NCrystal material object
   xt::xtensor<double, 1> atom_density_; //!< Nuclide atom density in [atom/b-cm]
   double density_;                      //!< Total atom density in [atom/b-cm]
   double density_gpcc_;                 //!< Total atom density in [g/cm^3]

--- a/include/openmc/ncrystal_interface.h
+++ b/include/openmc/ncrystal_interface.h
@@ -1,0 +1,91 @@
+#ifndef OPENMC_NCRYSTAL_INTERFACE_H
+#define OPENMC_NCRYSTAL_INTERFACE_H
+
+#ifdef NCRYSTAL
+#include "NCrystal/NCRNG.hh"
+#include "NCrystal/NCrystal.hh"
+#endif
+
+#include "openmc/particle.h"
+
+#include <cstdint> // for uint64_t
+#include <limits>  // for numeric_limits
+#include <string>
+
+namespace openmc {
+
+//==============================================================================
+// Constants
+//==============================================================================
+
+extern "C" const bool NCRYSTAL_ENABLED;
+
+//==============================================================================
+// Wrapper class an NCrystal material
+//==============================================================================
+
+class NCrystalMat {
+public:
+  //----------------------------------------------------------------------------
+  // Constructors
+  NCrystalMat() = default;
+  explicit NCrystalMat(const std::string& cfg);
+
+  //----------------------------------------------------------------------------
+  // Methods
+
+#ifdef NCRYSTAL
+  //! Return configuration string
+  std::string cfg() const;
+
+  //! Get cross section from NCrystal material
+  //
+  //! \param[in] p  Particle object
+  //! \return  Cross section in [b]
+  double xs(const Particle& p) const;
+
+  // Process scattering event
+  //
+  //! \param[in] p  Particle object
+  void scatter(Particle& p) const;
+
+  //! Whether the object holds a valid NCrystal material
+  operator bool() const;
+#else
+
+  //----------------------------------------------------------------------------
+  // Trivial methods when compiling without NCRYSTAL
+  std::string cfg() const
+  {
+    return "";
+  }
+  double xs(const Particle& p) const
+  {
+    return -1.0;
+  }
+  void scatter(Particle& p) const {}
+  operator bool() const
+  {
+    return false;
+  }
+#endif
+
+private:
+  //----------------------------------------------------------------------------
+  // Data members (only present when compiling with NCrystal support)
+#ifdef NCRYSTAL
+  std::string cfg_; //!< NCrystal configuration string
+  std::shared_ptr<const NCrystal::ProcImpl::Process>
+    ptr_; //!< Pointer to NCrystal material object
+#endif
+};
+
+//==============================================================================
+// Functions
+//==============================================================================
+
+void ncrystal_update_micro(double xs, NuclideMicroXS& micro);
+
+} // namespace openmc
+
+#endif // OPENMC_NCRYSTAL_INTERFACE_H

--- a/include/openmc/physics.h
+++ b/include/openmc/physics.h
@@ -96,8 +96,9 @@ void inelastic_scatter(const Nuclide& nuc, const Reaction& rx, Particle& p);
 
 void sample_secondary_photons(Particle& p, int i_nuclide);
 
-// ！Split or Roulette particles based their weight and the lower weight window
-//  bound.
+//! Split or Roulette particles based their weight and the lower weight window
+//! bound.
+//
 //! \param[in] p, particle to be split or rouletted with the weight window.
 void split_particle(Particle& p);
 

--- a/include/openmc/physics.h
+++ b/include/openmc/physics.h
@@ -8,10 +8,6 @@
 #include "openmc/reaction.h"
 #include "openmc/vector.h"
 
-#ifdef NCRYSTAL
-#include "NCrystal/NCRNG.hh"
-#endif
-
 namespace openmc {
 
 //==============================================================================
@@ -100,30 +96,10 @@ void inelastic_scatter(const Nuclide& nuc, const Reaction& rx, Particle& p);
 
 void sample_secondary_photons(Particle& p, int i_nuclide);
 
-//！Split or Roulette particles based their weight and the lower weight window
-// bound.
+// ！Split or Roulette particles based their weight and the lower weight window
+//  bound.
 //! \param[in] p, particle to be split or rouletted with the weight window.
 void split_particle(Particle& p);
-
-#ifdef NCRYSTAL
-//==============================================================================
-// NCrystal wrapper class for the OpenMC random number generator
-//==============================================================================
-
-class NCrystalRNGWrapper : public NCrystal::RNGStream {
-public:
-  constexpr NCrystalRNGWrapper(uint64_t* seed) noexcept : openmc_seed_(seed) {}
-
-protected:
-  double actualGenerate() override
-  {
-    return std::max<double>(
-      std::numeric_limits<double>::min(), prn(openmc_seed_));
-  }
-private:
-  uint64_t* openmc_seed_;
-};
-#endif
 
 } // namespace openmc
 

--- a/include/openmc/settings.h
+++ b/include/openmc/settings.h
@@ -20,8 +20,6 @@ namespace openmc {
 // Global variable declarations
 //==============================================================================
 
-extern "C" const bool NCRYSTAL_ENABLED;
-
 namespace settings {
 
 // Boolean flags
@@ -93,6 +91,8 @@ extern int n_log_bins;        //!< number of bins for logarithmic energy grid
 extern int n_batches;         //!< number of (inactive+active) batches
 extern int n_max_batches;     //!< Maximum number of batches
 extern int max_tracks; //!< Maximum number of particle tracks written to file
+extern double
+  ncrystal_max_energy; //!< Energy in eV to switch between NCrystal and ENDF
 extern ResScatMethod res_scat_method; //!< resonance upscattering method
 extern double res_scat_energy_min; //!< Min energy in [eV] for res. upscattering
 extern double res_scat_energy_max; //!< Max energy in [eV] for res. upscattering
@@ -124,10 +124,6 @@ extern int trigger_batch_interval; //!< Batch interval for triggers
 extern "C" int verbosity;          //!< How verbose to make output
 extern double weight_cutoff;       //!< Weight cutoff for Russian roulette
 extern double weight_survive;      //!< Survival weight after Russian roulette
-#ifdef NCRYSTAL
-extern double
-  ncrystal_max_energy; //!< Energy in eV to switch between NCrystal and ENDF
-#endif
 } // namespace settings
 
 //==============================================================================

--- a/src/ncrystal_interface.cpp
+++ b/src/ncrystal_interface.cpp
@@ -1,0 +1,108 @@
+#include "openmc/ncrystal_interface.h"
+
+#include "openmc/error.h"
+#include "openmc/material.h"
+#include "openmc/random_lcg.h"
+
+namespace openmc {
+
+//==============================================================================
+// Constants
+//==============================================================================
+
+#ifdef NCRYSTAL
+const bool NCRYSTAL_ENABLED = true;
+#else
+const bool NCRYSTAL_ENABLED = false;
+#endif
+
+//==============================================================================
+// NCrystal wrapper class for the OpenMC random number generator
+//==============================================================================
+
+#ifdef NCRYSTAL
+class NCrystalRNGWrapper : public NCrystal::RNGStream {
+public:
+  constexpr NCrystalRNGWrapper(uint64_t* seed) noexcept : openmc_seed_(seed) {}
+
+protected:
+  double actualGenerate() override
+  {
+    return std::max<double>(
+      std::numeric_limits<double>::min(), prn(openmc_seed_));
+  }
+
+private:
+  uint64_t* openmc_seed_;
+};
+#endif
+
+//==============================================================================
+// NCrystal implementation
+//==============================================================================
+
+NCrystalMat::NCrystalMat(const std::string& cfg)
+{
+#ifdef NCRYSTAL
+  cfg_ = cfg;
+  ptr_ = NCrystal::FactImpl::createScatter(cfg);
+#else
+  fatal_error("Your build of OpenMC does not support NCrystal materials.");
+#endif
+}
+
+#ifdef NCRYSTAL
+std::string NCrystalMat::cfg() const
+{
+  return cfg_;
+}
+
+double NCrystalMat::xs(const Particle& p) const
+{
+  // Calculate scattering XS per atom with NCrystal, only once per material
+  NCrystal::CachePtr dummy_cache;
+  auto nc_energy = NCrystal::NeutronEnergy {p.E()};
+  return ptr_->crossSection(dummy_cache, nc_energy, {p.u().x, p.u().y, p.u().z})
+    .get();
+}
+
+void NCrystalMat::scatter(Particle& p) const
+{
+  NCrystalRNGWrapper rng(p.current_seed()); // Initialize RNG
+  // create a cache pointer for multi thread physics
+  NCrystal::CachePtr dummy_cache;
+  auto nc_energy = NCrystal::NeutronEnergy {p.E()};
+  auto outcome = ptr_->sampleScatter(
+    dummy_cache, rng, nc_energy, {p.u().x, p.u().y, p.u().z});
+
+  // Modify attributes of particle
+  p.E() = outcome.ekin.get();
+  Direction u_old {p.u()};
+  p.u() =
+    Direction(outcome.direction[0], outcome.direction[1], outcome.direction[2]);
+  p.mu() = u_old.dot(p.u());
+  p.event_mt() = ELASTIC;
+}
+
+NCrystalMat::operator bool() const
+{
+  return ptr_.get();
+}
+#endif
+
+//==============================================================================
+// Functions
+//==============================================================================
+
+void ncrystal_update_micro(double xs, NuclideMicroXS& micro)
+{
+  if (micro.thermal > 0 || micro.thermal_elastic > 0) {
+    fatal_error("S(a,b) treatment and NCrystal are not compatible.");
+  }
+  // remove free atom cross section
+  // and replace it by scattering cross section per atom from NCrystal
+  micro.total = micro.total - micro.elastic + xs;
+  micro.elastic = xs;
+}
+
+} // namespace openmc

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -37,13 +37,6 @@ namespace openmc {
 // Global variables
 //==============================================================================
 
-#ifdef NCRYSTAL
-const bool NCRYSTAL_ENABLED = true;
-#else
-const bool NCRYSTAL_ENABLED = false;
-#endif
-
-
 namespace settings {
 
 // Default values for boolean flags
@@ -106,6 +99,7 @@ int n_batches;
 int n_max_batches;
 int max_splits {1000};
 int max_tracks {1000};
+double ncrystal_max_energy {5.0};
 ResScatMethod res_scat_method {ResScatMethod::rvs};
 double res_scat_energy_min {0.01};
 double res_scat_energy_max {1000.0};
@@ -127,10 +121,6 @@ int trigger_batch_interval {1};
 int verbosity {7};
 double weight_cutoff {0.25};
 double weight_survive {1.0};
-
-#ifdef NCRYSTAL
-double ncrystal_max_energy {5.0};
-#endif
 
 } // namespace settings
 

--- a/tests/regression_tests/ncrystal/test.py
+++ b/tests/regression_tests/ncrystal/test.py
@@ -1,3 +1,5 @@
+from math import pi
+
 import numpy as np
 import openmc
 import openmc.lib
@@ -8,6 +10,7 @@ from tests.testing_harness import PyAPITestHarness
 pytestmark = pytest.mark.skipif(
     not openmc.lib._ncrystal_enabled(),
     reason="NCrystal materials are not enabled.")
+
 
 def pencil_beam_model(cfg, E0, N):
     """Return an openmc.Model() object for a monoenergetic pencil
@@ -24,7 +27,7 @@ def pencil_beam_model(cfg, E0, N):
     sample_sphere = openmc.Sphere(r=0.1)
     outer_sphere = openmc.Sphere(r=100, boundary_type="vacuum")
     cell1 = openmc.Cell(region=-sample_sphere, fill=m1)
-    cell2_region= +sample_sphere & -outer_sphere
+    cell2_region = +sample_sphere & -outer_sphere
     cell2 = openmc.Cell(region=cell2_region, fill=None)
     geometry = openmc.Geometry([cell1, cell2])
 
@@ -48,7 +51,7 @@ def pencil_beam_model(cfg, E0, N):
     tally1 = openmc.Tally(name="angular distribution")
     tally1.scores = ["current"]
     filter1 = openmc.SurfaceFilter(sample_sphere)
-    filter2 = openmc.PolarFilter(np.linspace(0, np.pi, 180+1))
+    filter2 = openmc.PolarFilter(np.linspace(0, pi, 180+1))
     filter3 = openmc.CellFromFilter(cell1)
     tally1.filters = [filter1, filter2, filter3]
     tallies = openmc.Tallies([tally1])
@@ -66,11 +69,12 @@ class NCrystalTest(PyAPITestHarness):
             df = tal.get_pandas_dataframe()
         return df.to_string()
 
+
 def test_ncrystal():
-    NParticles = 100000
-    T = 293.6 # K
-    E0 = 0.012 # eV
+    n_particles = 100000
+    T = 293.6  # K
+    E0 = 0.012  # eV
     cfg = 'Al_sg225.ncmat'
-    test = pencil_beam_model(cfg, E0, NParticles)
+    test = pencil_beam_model(cfg, E0, n_particles)
     harness = NCrystalTest('statepoint.10.h5', model=test)
     harness.main()


### PR DESCRIPTION
@tkittel @marquezj I did some refactoring of the `mixed_ncrystal` branch to separate most of the NCrystal-related code into a new source file, `ncrystal_interface.cpp`. This allows the changes in the existing OpenMC source files to be pretty minimal. Also, when compiling without NCrystal, the compiler should be able to optimize away all of the NCrystal-related checking logic meaning that it doesn't incur any overhead. Hope you guys are OK with these changes!